### PR TITLE
Migrate to golangci-lint v2 and modernize CI/CD

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,42 +8,29 @@ on:
     branches: [ main ]
 
 env:
-  GO_VERSION: 1.26
-  GOLANGCI_LINT_VERSION: v1.64.8
+  GO_VERSION: "1.26"
+  GOLANGCI_LINT_VERSION: v2.12.2
 
 jobs:
   lint:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/setup-go@v4
+      - uses: actions/checkout@v7
+      - uses: actions/setup-go@v7
         with:
           go-version: ${{ env.GO_VERSION }}
-      - uses: actions/checkout@v3
-      - uses: golangci/golangci-lint-action@v3
+      - uses: golangci/golangci-lint-action@v9
         with:
           version: ${{ env.GOLANGCI_LINT_VERSION }}
-          # Build golangci-lint from source with the CI Go toolchain instead of
-          # downloading the prebuilt binary (which is built with go1.24 and can't
-          # typecheck this go1.25+ module — golang.org/x/tools v0.44.0 needs 1.25).
-          install-mode: goinstall
           args: --timeout=5m
 
   test:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/setup-go@v4
+      - uses: actions/checkout@v7
+      - uses: actions/setup-go@v7
         with:
           go-version: ${{ env.GO_VERSION }}
-      - uses: actions/checkout@v3
-
-      - uses: actions/cache@v3
-        with:
-          path: |
-            ~/.cache/go-build
-            ~/go/pkg/mod
-          key: ${{ runner.os }}-go-${{ matrix.go-version }}-${{ hashFiles('**/go.sum') }}
-          restore-keys: |
-            ${{ runner.os }}-go-${{ matrix.go-version }}
 
       - name: Tests with real databases
         run: make test.coverage
@@ -53,12 +40,12 @@ jobs:
           set -x
           COVERAGE_TOTAL=`go tool cover -func=coverage.out | grep total | grep -Eo '[0-9]+\.[0-9]+'`
           echo "COVERAGE_TOTAL=$COVERAGE_TOTAL" >> $GITHUB_ENV
-      - uses: jandelgado/gcov2lcov-action@v1.0.9
+      - uses: jandelgado/gcov2lcov-action@v1
         with:
           outfile: ./coverage.lcov
 
       - name: Coveralls
-        uses: coverallsapp/github-action@master
+        uses: coverallsapp/github-action@v2
         with:
-          path-to-lcov: ./coverage.lcov
+          file: ./coverage.lcov
           github-token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,26 +15,18 @@ jobs:
     runs-on: ubuntu-latest
     steps:
 
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
         with:
           fetch-depth: 0
 
-      - uses: actions/setup-go@v4
+      - uses: actions/setup-go@v7
         with:
           go-version: ${{ env.GO_VERSION }}
 
-      - uses: actions/cache@v3
-        if: ${{ !env.ACT }}
-        with:
-          path: ~/go/pkg/mod
-          key: ${{ runner.os }}-go-${{ matrix.golang }}-${{ hashFiles('**/go.sum') }}
-          restore-keys: |
-            ${{ runner.os }}-go-${{ matrix.golang }}-
-
       - name: GoReleaser
-        uses: goreleaser/goreleaser-action@v5
+        uses: goreleaser/goreleaser-action@v7
         with:
-          version: latest
+          version: '~> v2'
           args: release --clean
           workdir: cmd/gofactory/
         env:

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,36 +1,57 @@
-linters-settings:
-  dupl:
-    threshold: 100
-  lll:
-    line-length: 80
-  varnamelen:
-    ignore-names:
-      - v
-      - ok
-
+version: "2"
 linters:
-  enable-all: true
+  default: all
   disable:
-    - exhaustruct
     - depguard
+    - exhaustruct
     - thelper
-    - tenv
-
-issues:
-  exclude-dirs:
-    - testdata
-  exclude-rules:
-    - path: lint_test
-      linters:
-        - varnamelen
-        - wrapcheck
-    - linters:
-        - lll
-      source: "^(?: |\t)*// "
-    - linters:
-        - lll
-      source: "[`\"'].*[`\"']"
-    - linters:
-        - godot
-        - lll
-      source: "// ?TODO "
+    - wsl
+  settings:
+    dupl:
+      threshold: 100
+    lll:
+      line-length: 80
+    varnamelen:
+      ignore-names:
+        - v
+        - ok
+    funcorder:
+      constructor: true
+      struct-method: false
+      alphabetical: false
+      function: false
+  exclusions:
+    generated: lax
+    rules:
+      - linters:
+          - varnamelen
+          - wrapcheck
+        path: lint_test
+      - linters:
+          - lll
+        source: "^(?: |\t)*// "
+      - linters:
+          - lll
+        source: '[`"''].*[`"'']'
+      - linters:
+          - godot
+          - lll
+        source: '// ?TODO '
+    paths:
+      - testdata
+      - third_party$
+      - builtin$
+      - examples$
+formatters:
+  enable:
+    - gci
+    - gofmt
+    - gofumpt
+    - goimports
+  exclusions:
+    generated: lax
+    paths:
+      - testdata
+      - third_party$
+      - builtin$
+      - examples$

--- a/Makefile
+++ b/Makefile
@@ -7,7 +7,7 @@ COVERAGE_FILE="coverage.out"
 all: fmt lint test install
 
 fmt:
-	go fmt ./...
+	golangci-lint fmt
 
 lint:
 	golangci-lint run --fix ./...

--- a/cmd/gofactory/main.go
+++ b/cmd/gofactory/main.go
@@ -1,3 +1,4 @@
+// Lint CLI package.
 package main
 
 import (

--- a/factory.go
+++ b/factory.go
@@ -1,3 +1,4 @@
+// Package gofactory provides the main analyzer implementation.
 package gofactory
 
 import (
@@ -22,6 +23,7 @@ const (
 	onlyPkgGlobsDesc = "use a factory to initiate a structure for glob packages only"
 )
 
+// NewAnalyzer returns a new instance of the linter analyzer.
 func NewAnalyzer() *analysis.Analyzer {
 	analyzer := &analysis.Analyzer{
 		Name: name,
@@ -39,8 +41,8 @@ func NewAnalyzer() *analysis.Analyzer {
 	return analyzer
 }
 
-func run(cfg *config) func(pass *analysis.Pass) (interface{}, error) {
-	return func(pass *analysis.Pass) (interface{}, error) {
+func run(cfg *config) func(pass *analysis.Pass) (any, error) {
+	return func(pass *analysis.Pass) (any, error) {
 		var blockedStrategy blockedStrategy = newAnotherPkg()
 
 		pkgGlobs := cfg.pkgGlobs.Value()

--- a/lint_test.go
+++ b/lint_test.go
@@ -30,7 +30,8 @@ func TestLinterSuite(t *testing.T) {
 		"packageGlobsOnly": {
 			pkgs: []string{"packageGlobsOnly/main/..."},
 			prepare: func(_ *testing.T, a *analysis.Analyzer) error {
-				if err := a.Flags.Set("packageGlobs", "factory/packageGlobsOnly/blocked/**"); err != nil {
+				err := a.Flags.Set("packageGlobs", "factory/packageGlobsOnly/blocked/**")
+				if err != nil {
 					return err
 				}
 
@@ -51,7 +52,8 @@ func TestLinterSuite(t *testing.T) {
 			analyzer := gofactory.NewAnalyzer()
 
 			if tt.prepare != nil {
-				if err := tt.prepare(t, analyzer); err != nil {
+				err := tt.prepare(t, analyzer)
+				if err != nil {
 					t.Fatal(err)
 				}
 			}


### PR DESCRIPTION
- Migrate .golangci.yml to the v2 schema via `golangci-lint migrate`
- Bump golangci-lint v1.64.8 -> v2.12.2 and golangci-lint-action v3 -> v9
- make fmt: use `golangci-lint fmt` (gci, gofmt, gofumpt, goimports)
- Update GitHub Actions: checkout v7, setup-go v7, coveralls v2 (file input), gcov2lcov v1, goreleaser-action v7 (version: ~> v2)
- Drop manual actions/cache steps in favor of setup-go's built-in caching, gcov2lcov v1, goreleaser-action v7 (version: ~> v2)
- Drop manual actions/cache steps in favor of setup-go's built-in caching, and run checkout before setup-go so the cache can hash go.sum handling in tests, add missing doc comments